### PR TITLE
API improvments - discussion

### DIFF
--- a/example/index.php
+++ b/example/index.php
@@ -14,7 +14,9 @@
  */
 
 // autoloader when using Composer
-require ('../vendor/autoload.php');
+require (dirname(__DIR__) . '/vendor/autoload.php');
+
+use \Com\Tecnick\Barcode\Barcode;
 
 // autoloader when using RPM or DEB package installation
 //require ('/usr/share/php/Com/Tecnick/Barcode/autoload.php');
@@ -61,21 +63,19 @@ $square = array(
     'SRAW'       => array('0101,1010',  '2D RAW MODE (comma-separated rows of 01 strings)'),
 );
 
-$barcode = new \Com\Tecnick\Barcode\Barcode();
-
 $examples = '<h3>Linear</h3>'."\n";
 foreach ($linear as $type => $code) {
-    $bobj = $barcode->getBarcodeObj($type, $code[0], -3, -30, 'black', array(0, 0, 0, 0));
+    $bobj = Barcode::getBarcodeObj($type, $code[0], -3, -30, 'black', array(0, 0, 0, 0));
     $examples .= '<h4>[<span>'.$type.'</span>] '.$code[1].'</h4><p style="font-family:monospace;">'.$bobj->getHtmlDiv().'</p>'."\n";
 }
 
 $examples .= '<h3>Square</h3>'."\n";
 foreach ($square as $type => $code) {
-    $bobj = $barcode->getBarcodeObj($type, $code[0], -4, -4, 'black', array(0, 0, 0, 0));
+    $bobj = Barcode::getBarcodeObj($type, $code[0], -4, -4, 'black', array(0, 0, 0, 0));
     $examples .= '<h4>[<span>'.$type.'</span>] '.$code[1].'</h4><p style="font-family:monospace;">'.$bobj->getHtmlDiv().'</p>'."\n";
 }
 
-$bobj = $barcode->getBarcodeObj('QRCODE,H', 'http://www.tecnick.com', -4, -4, 'black', array(-2, -2, -2, -2));
+$bobj = Barcode::getBarcodeObj('QRCODE,H', 'http://www.tecnick.com', -4, -4, 'black', array(-2, -2, -2, -2));
 
 echo "
 <!DOCTYPE html>

--- a/src/Barcode.php
+++ b/src/Barcode.php
@@ -81,7 +81,7 @@ class Barcode
      *
      * @return array
      */
-    public function getTypes()
+    public static function getTypes()
     {
         return array_keys(self::$typeclass);
     }
@@ -103,7 +103,7 @@ class Barcode
      *
      * @throws BarcodeException in case of error
      */
-    public function getBarcodeObj(
+    public static function getBarcodeObj(
         $type,
         $code,
         $width = -1,

--- a/src/Type.php
+++ b/src/Type.php
@@ -198,6 +198,8 @@ abstract class Type
         $this->height_ratio = ($this->height / $this->nrows);
 
         $this->setPadding($padding);
+
+        return $this;
     }
 
     /**
@@ -208,7 +210,7 @@ abstract class Type
      *
      * @throws BarcodeException in case of error
      */
-    protected function setPadding($padding)
+    public function setPadding($padding)
     {
         if (!is_array($padding) || (count($padding) != 4)) {
             throw new BarcodeException('Invalid padding, expecting an array of 4 numbers (top, right, bottom, left)');
@@ -226,6 +228,8 @@ abstract class Type
             }
             $this->padding[$map[$key][0]] = $val;
         }
+
+        return $this;
     }
 
     /**
@@ -240,6 +244,8 @@ abstract class Type
         $webcolor = new \Com\Tecnick\Color\Web();
         $rgb = $webcolor->getColorObj($color)->toRgbArray();
         $this->color_obj = new \Com\Tecnick\Color\Model\Rgb($rgb);
+
+        return $this;
     }
 
     /**

--- a/test/BarcodePhp54Test.php
+++ b/test/BarcodePhp54Test.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * BarcodeTest.php
+ *
+ * @since       2015-02-21
+ * @category    Library
+ * @package     Barcode
+ * @author      Nicola Asuni <info@tecnick.com>
+ * @copyright   2015-2015 Nicola Asuni - Tecnick.com LTD
+ * @license     http://www.gnu.org/copyleft/lesser.html GNU-LGPL v3 (see LICENSE.TXT)
+ * @link        https://github.com/tecnick.com/tc-lib-barcode
+ *
+ * This file is part of tc-lib-barcode software library.
+ */
+
+namespace Test;
+
+/**
+ * Barcode class test
+ *
+ * @since       2015-02-21
+ * @category    Library
+ * @package     Barcode
+ * @author      Nicola Asuni <info@tecnick.com>
+ * @copyright   2015-2015 Nicola Asuni - Tecnick.com LTD
+ * @license     http://www.gnu.org/copyleft/lesser.html GNU-LGPL v3 (see LICENSE.TXT)
+ * @link        https://github.com/tecnick.com/tc-lib-barcode
+ */
+class BarcodeTestPhp54 extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (version_compare(PHP_VERSION, '5.4.0', '<')) {
+            $this->markTestSkipped("Need PHP >= 5.4"); // skip this test
+        }
+    }
+
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetPng()
+    {
+        ob_start();
+        \Com\Tecnick\Barcode\Barcode::getBarcodeObj(
+            'LRAW,AB,12,E3F',
+            '01001100011100001111,10110011100011110000'
+        )->setSize(-1,-1)
+         ->setColor('purple')
+         ->setPadding(array(-1,-1,-1,-1))
+         ->getPng();
+        $png = ob_get_clean();
+        $this->assertEquals('PNG', substr($png, 1, 3));
+    }
+}


### PR DESCRIPTION
This is mostly for discussion

Reading code, it seems getBarcodeObj is static, which make code simpler (no need to instanciate an object)

Having the setters returning $this seems a current practice, and allow to run

```
    \Com\Tecnick\Barcode\Barcode::getBarcodeObj(
        'LRAW,AB,12,E3F',
        '01001100011100001111,10110011100011110000'
    )->setSize(-1,-1)
     ->setColor('purple')
     ->setPadding(array(-1,-1,-1,-1))
     ->getPng();
```

Ok, this usage requires PHP > 5.4, but some could find it more legible (not having named parameters in PHP is a real lack...) Probably the test added for 5.4 could raise a parse error with 5.3.

We can even imagine further changes to write

```
    \Com\Tecnick\Barcode\Barcode::getBarcodeObj('LRAW')
       ->setCode('01001100011100001111,10110011100011110000')
       ->setParameters('AB','12','E3F')
       ->setSize(-1,-1)
       ->setColor('purple')
       ->setPadding([-1,-1,-1,-1])
       ->getPng();
```
