### PR TITLE
Fix for unicode in datamatrix barcode - calculation of ASCII number

### DIFF
--- a/src/Type/Square/Datamatrix.php
+++ b/src/Type/Square/Datamatrix.php
@@ -189,7 +189,7 @@ class Datamatrix extends \Com\Tecnick\Barcode\Type\Square
         $pos = 0; // current position
         $cdw = array(); // array of codewords to be returned
         $cdw_num = 0; // number of data codewords
-        $data_length = strlen($data); // number of chars
+        $data_length = mb_strlen($data); // number of chars
         while ($pos < $data_length) {
             // set last used encoding
             $this->dmx->last_enc = $enc;

--- a/src/Type/Square/Datamatrix/Encode.php
+++ b/src/Type/Square/Datamatrix/Encode.php
@@ -74,7 +74,7 @@ class Encode extends \Com\Tecnick\Barcode\Type\Square\Datamatrix\EncodeTxt
                 ++$cdw_num;
             } else {
                 // get new byte
-                $chr = ord($data[$pos]);
+                $chr = mb_ord(mb_substr($data, $pos, 1));
                 ++$pos;
                 if ($this->isCharMode($chr, Data::ENC_ASCII_EXT)) {
                     // 3. If the next data character is extended ASCII (greater than 127)
@@ -210,7 +210,7 @@ class Encode extends \Com\Tecnick\Barcode\Type\Square\Datamatrix\EncodeTxt
                 break; // exit from B256 mode
             } else {
                 // 2. Otherwise, process the next character in Base 256 encodation.
-                $chr = ord($data[$pos]);
+                $chr = mb_ord(mb_substr($data, $pos, 1));
                 ++$pos;
                 $temp_cw[] = $chr;
                 ++$field_length;


### PR DESCRIPTION
If a string contains unicode char $data[pos] will return wrong, use instead 

> $chr = mb_substr($data, $pos, 1) 

If char is unicode  ord($unicodeChar)  will return wrong, use instead  

>  mb_ord($chr) 

This will fix Unicode characters inside datamatrix barcode.  