### PR TITLE
Replace disallowed code points for xml doctype (svg)

### DIFF
--- a/src/Type.php
+++ b/src/Type.php
@@ -363,7 +363,7 @@ abstract class Type extends \Com\Tecnick\Barcode\Type\Convert
     {
         // flags for htmlspecialchars
         $hflag = ENT_NOQUOTES;
-        if (defined('ENT_XML1')) {
+        if (defined('ENT_XML1') && defined('ENT_DISALLOWED')) {
             $hflag = ENT_XML1 | ENT_DISALLOWED;
         }
         $width = sprintf('%F', ($this->width + $this->padding['L'] + $this->padding['R']));

--- a/src/Type.php
+++ b/src/Type.php
@@ -364,7 +364,7 @@ abstract class Type extends \Com\Tecnick\Barcode\Type\Convert
         // flags for htmlspecialchars
         $hflag = ENT_NOQUOTES;
         if (defined('ENT_XML1')) {
-            $hflag = ENT_XML1;
+            $hflag = ENT_XML1 | ENT_DISALLOWED;
         }
         $width = sprintf('%F', ($this->width + $this->padding['L'] + $this->padding['R']));
         $height = sprintf('%F', ($this->height + $this->padding['T'] + $this->padding['B']));


### PR DESCRIPTION
Not all UTF-8 valid characters are accepted in an XML document. These should be stripped.
An example of this would be the FNC1 character which usually corresponds to ASCII code 29, which is not allowed in XML.
See: https://www.w3.org/TR/REC-xml/#charsets