### PR TITLE
skip non hexa char. for 7.4

### DIFF
--- a/src/Type/Linear/MsiCheck.php
+++ b/src/Type/Linear/MsiCheck.php
@@ -77,10 +77,13 @@ class MsiCheck extends \Com\Tecnick\Barcode\Type\Linear
         $pix = 2;
         $check = 0;
         for ($pos = ($clen - 1); $pos >= 0; --$pos) {
-            $check += (hexdec($code[$pos]) * $pix);
-            ++$pix;
-            if ($pix > 7) {
-                $pix = 2;
+            $t = $code[$pos];
+            if ($t >= "0" && $t <= "9" || $t >= "a" && $t <= "f" || $t >= "A" && $t <= "F") {
+                $check += (hexdec($t) * $pix);
+                ++$pix;
+                if ($pix > 7) {
+                   $pix = 2;
+                }
             }
         }
         $check %= 11;


### PR DESCRIPTION
Without this:

```
There was 1 error:

1) Test\Linear\MsiCheckTest::testInvalidInput
Invalid characters passed for attempted conversion, these have been ignored

/dev/shm/BUILDROOT/php-tecnickcom-tc-lib-barcode-1.15.18-1.fc31.remi.x86_64/usr/share/php/Com/Tecnick/Barcode/Type/Linear/MsiCheck.php:80
/dev/shm/BUILDROOT/php-tecnickcom-tc-lib-barcode-1.15.18-1.fc31.remi.x86_64/usr/share/php/Com/Tecnick/Barcode/Type/Linear/MsiCheck.php:98
/dev/shm/BUILDROOT/php-tecnickcom-tc-lib-barcode-1.15.18-1.fc31.remi.x86_64/usr/share/php/Com/Tecnick/Barcode/Type/Linear/MsiCheck.php:110
/dev/shm/BUILDROOT/php-tecnickcom-tc-lib-barcode-1.15.18-1.fc31.remi.x86_64/usr/share/php/Com/Tecnick/Barcode/Type.php:171
/dev/shm/BUILDROOT/php-tecnickcom-tc-lib-barcode-1.15.18-1.fc31.remi.x86_64/usr/share/php/Com/Tecnick/Barcode/Barcode.php:122
/dev/shm/BUILD/tc-lib-barcode-853b29c4369b368e2c890084184bc4420b7707b8/test/Linear/MsiCheckTest.php:56

```

With:
```

PHPUnit 7.5.18 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.1
Configuration: /work/GIT/tc-lib-barcode/phpunit.xml.dist
Error:         No code coverage driver is available

...............................................................  63 / 197 ( 31%)
............................................................... 126 / 197 ( 63%)
............................................................... 189 / 197 ( 95%)
........                                                        197 / 197 (100%)

Time: 3,91 seconds, Memory: 14,00 MB

OK (197 tests, 272 assertions)

```