### PR TITLE
Fix of EDIFACT encode

### DIFF
--- a/src/Type/Square/Datamatrix/Encode.php
+++ b/src/Type/Square/Datamatrix/Encode.php
@@ -134,22 +134,31 @@ class Encode extends \Com\Tecnick\Barcode\Type\Square\Datamatrix\EncodeTxt
             return true;
         }
         if ($field_length < 4) {
-            // set unlatch character
-            $temp_cw[] = 0x1f;
-            ++$field_length;
-            // fill empty characters
-            for ($i = $field_length; $i < 4; ++$i) {
-                $temp_cw[] = 0;
-            }
             $enc = Data::ENC_ASCII;
             $this->last_enc = $enc;
+            $params = Data::getPaddingSize($this->shape, ($cdw_num + $field_length + ($data_length - $epos)));
+            if (($params[11] - $cdw_num) > 2) {
+                // set unlatch character
+                $temp_cw[] = 0x1f;
+                ++$field_length;
+                // fill empty characters
+                for ($i = $field_length; $i < 4; ++$i) {
+                    $temp_cw[] = 0;
+                }
+            } else {
+                return true;
+            }
         }
         // encodes four data characters in three codewords
-        if ($field_length > 2) {
-            $cdw[] = (($temp_cw[0] & 0x3F) << 2) + (($temp_cw[1] & 0x30) >> 4);
+        $cdw[] = (($temp_cw[0] & 0x3F) << 2) + (($temp_cw[1] & 0x30) >> 4);
+        $cdw_num++;
+        if ($field_length > 1) {
             $cdw[] = (($temp_cw[1] & 0x0F) << 4) + (($temp_cw[2] & 0x3C) >> 2);
+            $cdw_num++;
+        }
+        if ($field_length > 2) {
             $cdw[] = (($temp_cw[2] & 0x03) << 6) + ($temp_cw[3] & 0x3F);
-            $cdw_num += 3;
+            $cdw_num++;
         }
         $temp_cw = array();
         $pos = $epos;

--- a/test/Square/DatamatrixTest.php
+++ b/test/Square/DatamatrixTest.php
@@ -89,8 +89,12 @@ class DatamatrixTest extends TestUtil
     public function getGridDataProvider()
     {
         return array(
-            array('DATAMATRIX', '0&0&0&0&0&0&_', 'fffdfdaec33af0788d24cdfa8cba5ac6'),
-            array('DATAMATRIX', '0&0&0&0&0&0&0', '10d0faf5a6e7b71829f268218df7e6af'),
+            array('DATAMATRIX', '-=-1-=-2-=-3', '75c6038d90476cec641ad07690989b36'),
+            array('DATAMATRIX', '-=-1-=-2-=-3x', 'f020e44d0926d17af7eb21febdb38d53'),
+            array('DATAMATRIX', '-=-1-=-2-=-3xyz', '17420fbffefddb5f1b8abd0d05de724d'),
+            array('DATAMATRIX', '-=-1-=-2-=-3-', 'a63372ce839b51294964f0da0ae0f9f9'),
+            array('DATAMATRIX', '-=-1-=-2-=-3-xy', 'f65ab07c374c53e2a93016776041de42'),
+            array('DATAMATRIX', '-=-1-=-2-=-3-=x', '7a30efdf7616397a1ea2fd5fd95fed2c'),
             array('DATAMATRIX', '(400)BS2WZ64PA(00)0', '9cb7f1c2aa5989909229ef8e4252d61d'),
             array('DATAMATRIX', '(400)BS2WZ64QA(00)0', '0494f709138a1feef5a1c9f14852dbe5'),
             array('DATAMATRIX', 'LD2B 1 CLNGP', 'f806889d1dbe0908dcfb530f86098041'),
@@ -181,7 +185,7 @@ class DatamatrixTest extends TestUtil
                 .chr(29).chr(28).chr(27).chr(26).chr(25).chr(24).chr(23).chr(22).chr(21).chr(20).chr(19).chr(18)
                 .chr(17).chr(16).chr(15).chr(14).chr(13).chr(12).chr(11).chr(10).chr(9).chr(8).chr(7).chr(6)
                 .chr(5).chr(4).chr(3).chr(2).chr(1),
-                '4d755e3863cfdc79dc7ed5b8a781e479'
+                '514963c4fde0cee7ff91f76dd56015cc'
             ),
             // Rectangular shape
             array('DATAMATRIX,R', '01234567890', 'd3811e018f960beed6d3fa5e675e290e'),


### PR DESCRIPTION
International standard **ISO/IEC 16022:2006 Information technology — Automatic identification and data capture techniques — Data Matrix bar code symbology specification** reads as follows (sory, google-like translation from Russian):

> When EDIFACT encoding is terminated with an refusal sign of fixing of the coding scheme (Unlatch), any bits remaining in a character solitary sign should be filled with zeros. The ASCII encoding scheme starts at the next sign of the character. If the EDIFACT coding scheme is act until the end of the character, and before the first error correction sign only one or two codewords remain to be encoded, remaining after the last codewords triplet according to the EDIFACT coding scheme, they should be encoded using the ASCII encoding scheme without using refusal sign of fixing (Unlatch).

Corresponding corrections were made to the [`encodeEDFfour`](https://github.com/tecnickcom/tc-lib-barcode/pull/66/commits/c4c510455c72cf9dd3d3ef324a2767758a171f09) function to the [Encode.php](https://github.com/tecnickcom/tc-lib-barcode/blob/main/src/Type/Square/Datamatrix/Encode.php) file. Demonstrative test [items](https://github.com/tecnickcom/tc-lib-barcode/pull/66/commits/3a414d2cc49462a8c2cc732784b33464e74f180a) added to the [DatamatrixTest.php](https://github.com/tecnickcom/tc-lib-barcode/blob/main/test/Square/DatamatrixTest.php) file. They completely cover the corrected function.

In addition, the hash sum of a large barcode, containing ASCII characters with codes from 255 to 1, has been fixed. In library version 1.17.6 this barcode is generated incorrectly. I checked this with an industrial barcode scanner.