### PR TITLE
Fix deprecated implicit conversion from float to int

### DIFF
--- a/src/Type/Square/QrCode/Encoder.php
+++ b/src/Type/Square/QrCode/Encoder.php
@@ -208,14 +208,14 @@ class Encoder extends \Com\Tecnick\Barcode\Type\Square\QrCode\Init
     {
         if ($this->count < $this->dataLength) {
             $row = ($this->count % $this->blocks);
-            $col = ($this->count / $this->blocks);
+            $col = floor($this->count / $this->blocks);
             if ($col >= $this->rsblocks[0]['dataLength']) {
                 $row += $this->bv1;
             }
             $ret = $this->rsblocks[$row]['data'][$col];
         } elseif ($this->count < ($this->dataLength + $this->eccLength)) {
             $row = (($this->count - $this->dataLength) % $this->blocks);
-            $col = (($this->count - $this->dataLength) / $this->blocks);
+            $col = floor(($this->count - $this->dataLength) / $this->blocks);
             $ret = $this->rsblocks[$row]['ecc'][$col];
         } else {
             return 0;


### PR DESCRIPTION
On PHP 8.1, following deprecation error is trigerred.

Using `floor` produces the same result, without trigerring this deprecation error.

```
PHP Deprecated function (8192): Implicit conversion from float 28.5 to int loses precision in ./tecnickcom/tc-lib-barcode/src/Type/Square/QrCode/Encoder.php at line 219
  Backtrace :
  ./tecnickcom/tc-lib-barcode/src/Type/Square/QrCode/Encoder.php:169 Com\Tecnick\Barcode\Type\Square\QrCode\Encoder->getCode()
  ./tecnickcom/tc-lib-barcode/src/Type/Square/QrCode.php:223 Com\Tecnick\Barcode\Type\Square\QrCode\Encoder->encodeMask()
  ./tecnickcom/tc-lib-barcode/src/Type/Square/QrCode.php:179 Com\Tecnick\Barcode\Type\Square\QrCode->encodeString()
  ./tecnickcom/tc-lib-barcode/src/Type.php:171 Com\Tecnick\Barcode\Type\Square\QrCode->setBars()
  ./tecnickcom/tc-lib-barcode/src/Barcode.php:122 Com\Tecnick\Barcode\Type->__construct()
  script.php:134       Com\Tecnick\Barcode\Barcode->getBarcodeObj()
```